### PR TITLE
Don't add "I-care" classification to TNS sources

### DIFF
--- a/extensions/skyportal/skyportal/models/source_events.py
+++ b/extensions/skyportal/skyportal/models/source_events.py
@@ -19,6 +19,12 @@ def source_after_insert(mapper, connection, target):
 
     @event.listens_for(inspect(target).session, "after_flush", once=True)
     def receive_after_flush(session, context):
+
+        # first check if the obj.id is in the format 20YY[a-zA-Z] (e.g. 2021a, or 2024aaav)
+        # in which case we don't want to add the classification
+        tns_name_regex = r'20\d{2}[a-zA-Z]+'
+        if re.search(tns_name_regex, target.id):
+            return
         # find the taxonomy
         try:
             user = session.scalars(sa.select(User).where(User.id == 1)).first()

--- a/extensions/skyportal/skyportal/models/source_events.py
+++ b/extensions/skyportal/skyportal/models/source_events.py
@@ -21,9 +21,11 @@ def source_after_insert(mapper, connection, target):
     def receive_after_flush(session, context):
 
         # first check if the obj.id is in the format 20YY[a-zA-Z] (e.g. 2021a, or 2024aaav)
+        # it should be in that format and nothing else, meaning nothing before or after the 20YY[a-zA-Z] format
         # in which case we don't want to add the classification
         tns_name_regex = r'20\d{2}[a-zA-Z]+'
-        if re.search(tns_name_regex, target.id):
+        if re.fullmatch(tns_name_regex, target.id):
+            log(f"TNS object, not adding classification I-care")
             return
         # find the taxonomy
         try:

--- a/extensions/skyportal/skyportal/models/source_events.py
+++ b/extensions/skyportal/skyportal/models/source_events.py
@@ -25,7 +25,7 @@ def source_after_insert(mapper, connection, target):
         # in which case we don't want to add the classification
         tns_name_regex = r'20\d{2}[a-zA-Z]+'
         if re.fullmatch(tns_name_regex, target.id):
-            log(f"TNS object, not adding classification I-care")
+            log(f"TNS object {target.id}, not adding classification I-care")
             return
         # find the taxonomy
         try:


### PR DESCRIPTION
This PR prevents the backend DB trigger from add the I-care classification to sources with TNS names