### PR TITLE
Config: GCN Source Radius Threshold

### DIFF
--- a/icare.yaml.defaults
+++ b/icare.yaml.defaults
@@ -331,6 +331,7 @@ gcn:
     - Subthreshold
     - StarTrack_Lost_Lock
     - ECLAIRs-Catalog
+  source_radius_threshold: 12.0 # max skymap cone radius to create a source, in arcmin
 
 external_logging:
   sentry:


### PR DESCRIPTION
This PR simply adds the `source_radius_threshold` key to the `gcn` section of the config, with a default of 12 arcmin. Basically, this is the maximum radius allowed for a GCN event that provides a ra/dec/radius to auto-generate an associated source. While the default has been set to 8 in SkyPortal, as per Sarah's request we should set it to 12 for Icare. 

At the next deploy, the admin should make sure that this key is added to the `icare.yaml` config that's in use.