### PR TITLE
enh: Remove ztf infos in title of "Recent Sources (ZTF Kilonova/Swift)" 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__
 node_modules
 env
+venv
 geckodriver.log
 patched_skyportal
 previous_skyportal

--- a/extensions/skyportal/static/js/components/widget/RecentSources.jsx
+++ b/extensions/skyportal/static/js/components/widget/RecentSources.jsx
@@ -552,7 +552,7 @@ const RecentSources = ({ classes }) => {
       <div className={classes.widgetPaperDiv}>
         <div>
           <Typography variant="h6" display="inline">
-            Recent Sources (ZTF Kilonova/Swift)
+            Recent Sources
           </Typography>
           <DragHandleIcon className={`${classes.widgetIcon} dragHandle`} />
           <div className={classes.widgetIcon}>


### PR DESCRIPTION
Remove ztf infos in title of "Recent Sources (ZTF Kilonova/Swift)" as requested by Patrice and Sarah.

Preview :
![image](https://github.com/user-attachments/assets/58e1260b-7c2d-4b8b-bed1-1fd024b8f5eb)
becoming
![image](https://github.com/user-attachments/assets/a74fa5f5-0e67-46d3-92bd-dd082453e714)
