### PR TITLE
Create tarot proxy callable by other skyportal

### DIFF
--- a/extensions/skyportal/baselayer/services/nginx/nginx.conf.template
+++ b/extensions/skyportal/baselayer/services/nginx/nginx.conf.template
@@ -1,0 +1,237 @@
+error_log log/error.log error;
+pid run/nginx.pid;
+
+{% if fill_config_feature.nginx_brotli.dynamic and fill_config_feature.nginx_brotli.modules_path %}
+load_module {{ fill_config_feature.nginx_brotli.modules_path }}/ngx_http_brotli_filter_module.so; # for compressing responses on-the-fly
+load_module {{ fill_config_feature.nginx_brotli.modules_path }}/ngx_http_brotli_static_module.so; # for serving pre-compressed files
+{% endif %}
+
+
+# Choose number of NGINX worker processes based on number of CPUs
+worker_processes auto;
+
+http {
+  sendfile on;
+  tcp_nopush on;
+  types_hash_max_size 4096;
+
+  # Enable compression of outgoing data
+  gzip on;
+  gzip_min_length 1000;
+  gzip_proxied any;
+  gzip_types text/plain
+             text/css
+             application/json
+             application/x-javascript
+             application/xml
+             text/javascript
+             application/javascript;
+
+  {% if fill_config_feature.nginx_brotli.installed %}
+  # also enable brotli compression
+  brotli on;
+  brotli_comp_level 6;
+  brotli_types text/plain
+               text/css
+               application/json
+               application/x-javascript
+               application/xml
+               text/javascript
+               application/javascript;
+  {% endif %}
+
+  # Only retry if there was a communication error, not a timeout
+  # on the Tornado server (to avoid propagating "queries of death"
+  # to all frontends)
+  #
+  # See https://www.tornadoweb.org/en/stable/guide/running.html
+  proxy_next_upstream error;
+
+  {% for ip in server.loadbalancer_ips -%}
+    set_real_ip_from {{ ip }};
+  {% endfor %}
+  real_ip_header X-Forwarded-For;
+  real_ip_recursive on;
+
+  geo $limit {
+    default 1;
+    127.0.0.1/32 0;
+    {% for ip in server.whitelisted_ips -%}
+      {{ ip }} 0;
+    {% endfor %}
+  }
+
+  map $limit $limit_key {
+    0 "";
+    1 $http_authorization;
+  }
+
+  # Per-token API rate limiting
+  limit_req_zone $limit_key zone=custom_rate_limit:1m rate={{ server.rate_limit }}r/s;
+
+  upstream websocket_server {
+    server localhost:{{ ports.websocket }};
+  }
+
+  upstream fakeoauth_server {
+    server localhost:{{ ports.fake_oauth }};
+  }
+
+  upstream frontend {
+    least_conn;
+    {% for p in range(server.processes) -%}
+      server 127.0.0.1:{{ ports.app_internal + p }} fail_timeout={{ server.fail_timeout }}s;
+    {% endfor %}
+    server 127.0.0.1:{{ ports.status }} backup max_fails=0;
+  }
+
+  # Only a subset of processes are available for token authenticated API
+  # requests.  This ensures that even when the system is being
+  # hit by API requests, the frontend remains responsive.
+  upstream api {
+    least_conn;
+    {% for p in range(server.dedicated_frontend_processes, [server.processes, server.dedicated_frontend_processes + 1] | max) -%}
+      server 127.0.0.1:{{ ports.app_internal + p }} fail_timeout={{ server.fail_timeout }}s;
+    {% endfor %}
+    server 127.0.0.1:{{ ports.status }} backup max_fails=0;
+  }
+
+  # See http://nginx.org/en/docs/http/websocket.html
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+  }
+
+  map $http_authorization $pool {
+    default frontend;
+    '~.' api;
+  }
+
+  map $request_method $exclude_head_requests {
+    HEAD    0;
+    default 1;
+  }
+
+  map $status $loggable {
+      ~^[2]   $exclude_head_requests;
+      ~^[3]   0;
+      ~^[101] 0;
+      404     $exclude_head_requests;
+      default 1;
+  }
+
+  map $http_authorization $trunc_authorization {
+    default "";
+    "~*(?P<tr>.{0,14}).*" $tr;
+  }
+
+  log_format elb_log '$remote_addr - $remote_user [$trunc_authorization] [$time_local] ' '"$request" $status $body_bytes_sent rl=$request_length "$http_referer" ' '"$http_user_agent"';
+
+  server {
+    {% if env.debug %}
+    listen 127.0.0.1:{{ ports.app }};
+    {% else %}
+    {% if server.ssl_certificate %}
+    listen {{ ports.app }} ssl;
+    {% else %}
+    listen {{ ports.app }};
+    {% endif %}
+    listen {{ ports.app_http_proxy }} proxy_protocol; # This is for AWS Elastic Load Balancer
+    {% endif %}
+    client_max_body_size {{ server.max_body_size }}M;
+
+    {% if server.ssl_certificate %}
+    ssl_certificate {{ server.ssl_certificate }};
+    ssl_certificate_key {{ server.ssl_certificate_key }};
+    {% endif %}
+
+    location / {
+      # API rate limiting
+      limit_req zone=custom_rate_limit burst={{ server.burst }} nodelay;
+      limit_req_status 429;
+
+      proxy_pass http://$pool;
+
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+
+      # Buffer sizes; see
+      # https://www.getpagespeed.com/server-setup/nginx/tuning-proxy_buffer_size-in-nginx
+
+      # Handle uploads up to 64k before buffering to disk
+      client_body_buffer_size 64k;
+
+      # Buffer responses up to 256k
+      proxy_buffers 32 8k;
+
+      # Serve static files directly
+      location /static/ {
+        root .;
+        include mime.types;
+        if ($query_string) {
+          expires max;
+        }
+      }
+      location /favicon.png {
+        root static;
+        expires max;
+      }
+    }
+
+    location /websocket {
+        proxy_pass http://websocket_server/websocket;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_read_timeout 60s;
+    }
+
+    location /fakeoauth2 {
+        proxy_pass http://fakeoauth_server/fakeoauth2;
+    }
+
+    location /api/tarot_proxy/ {
+        # API rate limiting
+        limit_req zone=custom_rate_limit burst=10 nodelay;
+        limit_req_status 429;
+
+        proxy_pass http://127.0.0.1:64910/;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Handle uploads up to 64k before buffering to disk
+        client_body_buffer_size 64k;
+
+        # Buffer responses up to 256k
+        proxy_buffers 32 8k;
+    }
+
+    error_log log/nginx-error.log warn;
+    # one of: debug, info, notice, warn, error, crit, alert, emerg
+
+{% if log.api_calls %}
+    {% set log_cond = "" %}
+{% else %}
+    {% set log_cond = "if=$loggable" %}
+{% endif %}
+    access_log log/nginx-access.log elb_log {{ log_cond }};
+  }
+
+  # Set an array of temp and cache file options that will otherwise default to
+  # restricted locations accessible only to root.
+  client_body_temp_path tmp/client_body;
+  fastcgi_temp_path tmp/fastcgi_temp;
+  proxy_temp_path tmp/proxy_temp;
+  scgi_temp_path tmp/scgi_temp;
+  uwsgi_temp_path tmp/uwsgi_temp;
+
+}
+
+events {
+  worker_connections 1024;
+}

--- a/extensions/skyportal/services/tarot_proxy/supervisor.conf
+++ b/extensions/skyportal/services/tarot_proxy/supervisor.conf
@@ -1,0 +1,5 @@
+[program:tarot_proxy]
+command=/usr/bin/env python services/tarot_proxy/tarot_proxy.py %(ENV_FLAGS)s
+environment=PYTHONPATH=".",PYTHONUNBUFFERED="1"
+stdout_logfile=log/tarot_proxy.log
+redirect_stderr=true

--- a/extensions/skyportal/services/tarot_proxy/tarot_proxy.py
+++ b/extensions/skyportal/services/tarot_proxy/tarot_proxy.py
@@ -1,0 +1,108 @@
+import requests
+import tornado.escape
+import tornado.web
+from sqlalchemy.orm import scoped_session, sessionmaker
+from tornado.ioloop import IOLoop
+
+from baselayer.app.models import init_db
+from baselayer.app.access import auth_or_token
+from baselayer.app.env import load_env
+from baselayer.log import make_log
+from baselayer.app.handlers.base import BaseHandler
+
+from skyportal.utils.services import check_loaded
+
+env, cfg = load_env()
+log = make_log("tarot_proxy")
+
+TAROT_BASE_URL = cfg.get("app.tarot_endpoint")
+TAROT_CALERN_URL = cfg.get("app.calern_endpoint")
+TAROT_CHILI_URL = cfg.get("app.chili_endpoint")
+TAROT_REUNION_URL = cfg.get("app.reunion_endpoint")
+PORT = cfg.get("ports.tarot_proxy")
+
+is_configured = TAROT_BASE_URL and TAROT_CALERN_URL and TAROT_CHILI_URL and TAROT_REUNION_URL and PORT
+
+init_db(**cfg["database"])
+
+Session = scoped_session(sessionmaker())
+
+
+class TarotProxyHandler(BaseHandler):
+    def prepare(self):
+        path = self.request.path
+
+        if path.startswith("/tarot_calern"):
+            base_url = TAROT_CALERN_URL
+            specific_path = path.replace("/tarot_calern", "")
+        elif path.startswith("/tarot_chili"):
+            base_url = TAROT_CHILI_URL
+            specific_path = path.replace("/tarot_chili", "")
+        elif path.startswith("/tarot_reunion"):
+            base_url = TAROT_REUNION_URL
+            specific_path = path.replace("/tarot_reunion", "")
+        else:
+            base_url = TAROT_BASE_URL
+            specific_path = path
+
+        self.tarot_url = f"{base_url}{specific_path}"
+
+    def forward_request(self):
+        method = self.request.method
+
+        browser_username = self.request.headers.get("X-Browser-Username")
+        browser_password = self.request.headers.get("X-Browser-Password")
+
+        # Exclude icare, browser authentication and host header to use the real target host,
+        exclude = {"authorization", "x-browser-username", "x-browser-password", "host"}
+        headers = {k: v for k, v in self.request.headers.items() if k.lower() not in exclude}
+
+        query = self.request.query
+        full_url = f"{self.tarot_url}?{query}" if query else self.tarot_url
+        resp = requests.request(
+            method,
+            full_url,
+            headers=headers,
+            auth=(browser_username, browser_password),
+            data=self.request.body,
+            allow_redirects=True,
+            timeout=5,
+        )
+        self.set_status(resp.status_code)
+        for key, value in resp.headers.items():
+            # Exclude headers that should not be set in the response
+            if key.lower() not in {"content-length", "transfer-encoding", "connection"}:
+                self.set_header(key, value)
+        self.finish(resp.content)
+
+    @auth_or_token
+    def get(self):
+        self.forward_request()
+
+    @auth_or_token
+    def post(self):
+        self.forward_request()
+
+    @auth_or_token
+    def delete(self):
+        self.forward_request()
+
+
+@check_loaded(logger=log)
+def service(*args, **kwargs):
+    """Start the Tarot proxy service."""
+    app = tornado.web.Application([(r"/.*", TarotProxyHandler)])
+    app.listen(PORT)
+    log(f"TAROT proxy listening on port {PORT}")
+    IOLoop.current().start()
+
+
+if __name__ == "__main__":
+    """Start the Tarot proxy server"""
+    if not is_configured:
+        raise ValueError("tarot_endpoint, calern_endpoint, chili_endpoint, reunion_endpoint and ports.tarot_proxy must be set in the configuration.")
+    try:
+        service()
+    except Exception as e:
+        log(f"Error occurred while starting TAROT proxy: {str(e)}")
+        raise e

--- a/icare.yaml.defaults
+++ b/icare.yaml.defaults
@@ -5,6 +5,13 @@ app:
     default_filters: ['ztfg', 'ztfr', 'ztfi']
     use_skyportal_fields: False
 
+  # Tarot API endpoints
+  tarot_proxy_endpoint: http://127.0.0.1/api/tarot_proxy
+  tarot_endpoint: http://cador.tarotnet.org/ros
+  calern_endpoint: http://tca4.tarotnet.org/ros/klotz
+  chili_endpoint: http://tch4.tarotnet.org/ros/klotz
+  reunion_endpoint: http://tre4.tarotnet.org/ros/klotz
+
   routes:
     - path: "/"
       component: templates/DashboardGrandma
@@ -284,6 +291,9 @@ server:
 
 services:
   dask: False
+
+ports:
+  tarot_proxy: 64910
 
 notifications:
   enabled: True

--- a/icare.yaml.defaults
+++ b/icare.yaml.defaults
@@ -1,3 +1,6 @@
+ports:
+  tarot_proxy: 64910
+
 app:
   title: Icare
   factory: skyportal.app_server_icare.make_app_icare
@@ -6,7 +9,7 @@ app:
     use_skyportal_fields: False
 
   # Tarot API endpoints
-  tarot_proxy_endpoint: http://127.0.0.1/api/tarot_proxy
+  tarot_proxy_endpoint: http://localhost:64910/
   tarot_endpoint: http://cador.tarotnet.org/ros
   calern_endpoint: http://tca4.tarotnet.org/ros/klotz
   chili_endpoint: http://tch4.tarotnet.org/ros/klotz
@@ -291,9 +294,6 @@ server:
 
 services:
   dask: False
-
-ports:
-  tarot_proxy: 64910
 
 notifications:
   enabled: True


### PR DESCRIPTION
This PR introduces a new standalone service (tarot_proxy) that acts as a proxy for forwarding requests to the TAROT server. Other SkyPortal instances can now send requests through this proxy by targeting Icare tarot_proxy endpoint.