### PR TITLE
Fix tarot proxy error with gzip content

### DIFF
--- a/extensions/skyportal/services/tarot_proxy/tarot_proxy.py
+++ b/extensions/skyportal/services/tarot_proxy/tarot_proxy.py
@@ -67,13 +67,15 @@ class TarotProxyHandler(BaseHandler):
             data=self.request.body,
             allow_redirects=True,
             timeout=5,
+            stream=True,
         )
+        resp.raw.decode_content = False
         self.set_status(resp.status_code)
         for key, value in resp.headers.items():
             # Exclude headers that should not be set in the response
             if key.lower() not in {"content-length", "transfer-encoding", "connection"}:
                 self.set_header(key, value)
-        self.finish(resp.content)
+        self.finish(resp.raw.read())
 
     @auth_or_token
     def get(self):


### PR DESCRIPTION
Fix proxy by disabling automatic decompression and forward raw response content to allow correct handling of gzip-encoded data by skyportal tarot API.

Error:
`Error retrieving photometry request: ('Received response with content-encoding: gzip, but failed to decode it.', error('Error -3 while decompressing data: incorrect header check'))`