### PR TITLE
ACME: Remove grandma from the default group for a new user 

### DIFF
--- a/icare.yaml.defaults
+++ b/icare.yaml.defaults
@@ -307,8 +307,7 @@ notifications:
 
 user:
   default_role: 'Full user'
-  default_groups: ['GRANDMA']
-  default_acls: ['Manage shifts']
+  default_groups: ['Sitewide Group']
 
 fink:
   fink_topics:

--- a/icare.yaml.defaults
+++ b/icare.yaml.defaults
@@ -307,7 +307,6 @@ notifications:
 
 user:
   default_role: 'Full user'
-  default_groups: ['Sitewide Group']
 
 fink:
   fink_topics:


### PR DESCRIPTION
The goal of this PR is to prepare the platform opening related to the ACME program.   
New users should not be in the GRANDMA group by default anymore. This PR also remove the right to Manage Shift which is put by default in the configuration.