### PR TITLE
Update fink photometry endpoint

### DIFF
--- a/extensions/skyportal/skyportal/handlers/api/fink_photometry.py
+++ b/extensions/skyportal/skyportal/handlers/api/fink_photometry.py
@@ -1,81 +1,88 @@
-from baselayer.app.access import auth_or_token
-import requests
-import pandas as pd
 import io
 
+import pandas as pd
+import requests
+from astropy.time import Time
+from baselayer.app.access import auth_or_token
+from baselayer.log import make_log
 from skyportal.models.obj import Obj
 
-from ..base import BaseHandler
 from ...models import Instrument
-from astropy.time import Time
+from ..base import BaseHandler
 from .photometry import add_external_photometry
 
-FINK_ZTF_API = 'https://api.ztf.fink-portal.org'
-FINK_LSST_API = 'https://api.lsst.fink-portal.org'
+log = make_log("api/fink_photometry")
 
-ZTF_BANDS = {1: 'ztfg', 2: 'ztfr', 3: 'ztfi'}
-LSST_BANDS = {'u': 'lsstu', 'g': 'lsstg', 'r': 'lsstr', 'i': 'lssti', 'z': 'lsstz', 'y': 'lssty'}
+FINK_ZTF_API = "https://api.ztf.fink-portal.org"
+FINK_LSST_API = "https://api.lsst.fink-portal.org"
 
-# Keep legacy alias for backwards compatibility
+ZTF_BANDS = {1: "ztfg", 2: "ztfr", 3: "ztfi"}
+LSST_BANDS = {
+    "u": "lsstu",
+    "g": "lsstg",
+    "r": "lsstr",
+    "i": "lssti",
+    "z": "lsstz",
+    "y": "lssty",
+}
+
 bands = ZTF_BANDS
 
 FINK_SURVEYS = [
     {
-        'name': 'ztf',
-        'base_url': FINK_ZTF_API,
-        'instrument_name': 'ZTF',
+        "name": "ztf",
+        "base_url": FINK_ZTF_API,
+        "instrument_name": "ZTF",
     },
     {
-        'name': 'lsst',
-        'base_url': FINK_LSST_API,
-        'instrument_name': 'LSST',
+        "name": "lsst",
+        "base_url": FINK_LSST_API,
+        "instrument_name": "LSST",
     },
 ]
 
+FINK_ALTDATA = {"imported_from": "fink"}
 
-def _resolve_fink_objects(names):
+
+def _resolve_fink_objects(tns_name):
     """
-    Resolve a list of names (object ID + aliases) using Fink TNS resolvers.
+    Resolve a TNS name using Fink TNS resolvers on both ZTF and LSST endpoints.
 
-    For each name, queries both ZTF and LSST Fink resolvers and returns a
-    deduplicated list of (survey_name, fink_object_id) tuples.
+    Returns a deduplicated list of (survey_name, fink_object_id) tuples.
     """
     results = []
     seen = set()
-    for name in names:
-        if not name:
-            continue
-        for survey in FINK_SURVEYS:
-            try:
-                r = requests.get(
-                    f'{survey["base_url"]}/api/v1/resolver',
-                    params={'name': name, 'resolver': 'tns'},
-                    timeout=10,
-                )
-                if r.status_code != 200 or not r.content:
-                    continue
-                data = r.json()
-                if not isinstance(data, list):
-                    continue
-                for item in data:
-                    obj_id = item.get('i:objectId') or item.get('d:objectId')
-                    key = (survey['name'], obj_id)
-                    if obj_id and key not in seen:
-                        seen.add(key)
-                        results.append(key)
-            except Exception:
+    for survey in FINK_SURVEYS:
+        try:
+            r = requests.get(
+                f"{survey['base_url']}/api/v1/resolver",
+                params={"name": tns_name, "resolver": "tns"},
+                timeout=10,
+            )
+            if r.status_code != 200 or not r.content:
                 continue
+            data = r.json()
+            if not isinstance(data, list):
+                continue
+            for item in data:
+                obj_id = item.get("i:objectId") or item.get("d:objectId")
+                key = (survey["name"], obj_id)
+                if obj_id and key not in seen:
+                    seen.add(key)
+                    results.append(key)
+        except Exception:
+            continue
     return results
 
 
 def _fetch_ztf_photometry(fink_object_id, obj_id, instrument_id, group_ids, user):
     """Fetch ZTF photometry from Fink and post it to SkyPortal."""
     r = requests.post(
-        f'{FINK_ZTF_API}/api/v1/objects',
+        f"{FINK_ZTF_API}/api/v1/objects",
         json={
-            'objectId': fink_object_id,
-            'output-format': 'json',
-            'withupperlim': True,
+            "objectId": fink_object_id,
+            "output-format": "json",
+            "withupperlim": True,
         },
     )
     if r.status_code != 200:
@@ -88,14 +95,14 @@ def _fetch_ztf_photometry(fink_object_id, obj_id, instrument_id, group_ids, user
         return
 
     desired_columns = [
-        'i:objectId',
-        'i:ra',
-        'i:dec',
-        'i:magpsf',
-        'i:sigmapsf',
-        'i:diffmaglim',
-        'i:fid',
-        'i:jd',
+        "i:objectId",
+        "i:ra",
+        "i:dec",
+        "i:magpsf",
+        "i:sigmapsf",
+        "i:diffmaglim",
+        "i:fid",
+        "i:jd",
     ]
     if not set(desired_columns).issubset(set(df.columns)):
         raise ValueError(
@@ -103,17 +110,18 @@ def _fetch_ztf_photometry(fink_object_id, obj_id, instrument_id, group_ids, user
         )
 
     data = {
-        'obj_id': [obj_id] * len(df),
-        'ra': df['i:ra'],
-        'dec': df['i:dec'],
-        'mag': df['i:magpsf'],
-        'magerr': df['i:sigmapsf'],
-        'limiting_mag': df['i:diffmaglim'],
-        'filter': [ZTF_BANDS[int(band)] for band in df['i:fid']],
-        'mjd': [Time(float(jd), format="jd").mjd for jd in df["i:jd"]],
-        'magsys': ['ab'] * len(df),
-        'instrument_id': instrument_id,
-        'group_ids': group_ids,
+        "obj_id": [obj_id] * len(df),
+        "ra": df["i:ra"],
+        "dec": df["i:dec"],
+        "mag": df["i:magpsf"],
+        "magerr": df["i:sigmapsf"],
+        "limiting_mag": df["i:diffmaglim"],
+        "filter": [ZTF_BANDS[int(band)] for band in df["i:fid"]],
+        "mjd": [Time(float(jd), format="jd").mjd for jd in df["i:jd"]],
+        "magsys": ["ab"] * len(df),
+        "instrument_id": instrument_id,
+        "group_ids": group_ids,
+        "altdata": FINK_ALTDATA,
     }
     add_external_photometry(data, user)
     return len(df)
@@ -122,11 +130,11 @@ def _fetch_ztf_photometry(fink_object_id, obj_id, instrument_id, group_ids, user
 def _fetch_lsst_photometry(fink_object_id, obj_id, instrument_id, group_ids, user):
     """Fetch LSST photometry from Fink (flux-space, nJy, zp=31.4) and post it to SkyPortal."""
     r = requests.post(
-        f'{FINK_LSST_API}/api/v1/objects',
+        f"{FINK_LSST_API}/api/v1/sources",
         json={
-            'objectId': fink_object_id,
-            'output-format': 'json',
-            'withupperlim': True,
+            "diaObjectId": str(fink_object_id),
+            "columns": "r:ra,r:dec,r:psfFlux,r:psfFluxErr,r:band,r:midpointMjdTai",
+            "output-format": "json",
         },
     )
     if r.status_code != 200:
@@ -139,37 +147,35 @@ def _fetch_lsst_photometry(fink_object_id, obj_id, instrument_id, group_ids, use
         return
 
     desired_columns = [
-        'd:objectId',
-        'd:ra',
-        'd:dec',
-        'd:psfFlux',
-        'd:psfFluxErr',
-        'd:band',
-        'd:midpointMjdTai',
+        "r:ra",
+        "r:dec",
+        "r:psfFlux",
+        "r:psfFluxErr",
+        "r:band",
+        "r:midpointMjdTai",
     ]
     if not set(desired_columns).issubset(set(df.columns)):
         raise ValueError(
             f"Missing expected columns in Fink LSST response for object {fink_object_id}"
         )
 
-    unknown_bands = set(df['d:band']) - set(LSST_BANDS)
+    unknown_bands = set(df["r:band"]) - set(LSST_BANDS)
     if unknown_bands:
-        raise ValueError(
-            f"Unknown LSST band(s) in Fink response: {unknown_bands}"
-        )
+        raise ValueError(f"Unknown LSST band(s) in Fink response: {unknown_bands}")
 
     data = {
-        'obj_id': [obj_id] * len(df),
-        'ra': df['d:ra'],
-        'dec': df['d:dec'],
-        'flux': df['d:psfFlux'],
-        'fluxerr': df['d:psfFluxErr'],
-        'filter': [LSST_BANDS[b] for b in df['d:band']],
-        'mjd': df['d:midpointMjdTai'],
-        'magsys': ['ab'] * len(df),
-        'zp': [31.4] * len(df),
-        'instrument_id': instrument_id,
-        'group_ids': group_ids,
+        "obj_id": [obj_id] * len(df),
+        "ra": df["r:ra"],
+        "dec": df["r:dec"],
+        "flux": df["r:psfFlux"],
+        "fluxerr": df["r:psfFluxErr"],
+        "filter": [LSST_BANDS[b] for b in df["r:band"]],
+        "mjd": df["r:midpointMjdTai"],
+        "magsys": ["ab"] * len(df),
+        "zp": [31.4] * len(df),
+        "instrument_id": instrument_id,
+        "group_ids": group_ids,
+        "altdata": FINK_ALTDATA,
     }
     add_external_photometry(data, user)
     return len(df)
@@ -179,10 +185,20 @@ def _fetch_photometry_for_survey(
     survey_name, fink_object_id, obj_id, instrument_id, group_ids, user
 ):
     """Dispatch photometry fetching to the correct survey handler. Returns row count."""
-    if survey_name == 'ztf':
-        return _fetch_ztf_photometry(fink_object_id, obj_id, instrument_id, group_ids, user) or 0
-    elif survey_name == 'lsst':
-        return _fetch_lsst_photometry(fink_object_id, obj_id, instrument_id, group_ids, user) or 0
+    if survey_name == "ztf":
+        return (
+            _fetch_ztf_photometry(
+                fink_object_id, obj_id, instrument_id, group_ids, user
+            )
+            or 0
+        )
+    elif survey_name == "lsst":
+        return (
+            _fetch_lsst_photometry(
+                fink_object_id, obj_id, instrument_id, group_ids, user
+            )
+            or 0
+        )
     return 0
 
 
@@ -194,11 +210,11 @@ class FinkPhotometryHandler(BaseHandler):
         object_id = object_id.strip()
 
         data = self.get_json()
-        current_magsys = data.get('magsys', 'ab')
+        current_magsys = data.get("magsys", "ab")
         if current_magsys is None:
-            current_magsys = 'ab'
-        elif current_magsys not in ['ab', 'vega']:
-            return self.error('Invalid magsys, must be either ab or vega')
+            current_magsys = "ab"
+        elif current_magsys not in ["ab", "vega"]:
+            return self.error("Invalid magsys, must be either ab or vega")
 
         try:
             with self.Session() as session:
@@ -214,27 +230,28 @@ class FinkPhotometryHandler(BaseHandler):
                     if not g.single_user_group
                 ]
 
-                # Collect all names to try: the skyportal object ID plus any aliases
-                names_to_resolve = [object_id] + (obj.alias or [])
-
-                # Try to resolve via Fink TNS resolvers on both ZTF and LSST endpoints
-                resolved = _resolve_fink_objects(names_to_resolve)
+                # Try to resolve via Fink TNS resolvers using the TNS name only.
+                # The object ID and aliases are native survey IDs and are tested
+                # directly against the Fink APIs in the fallback path below.
+                resolved = []
+                if obj.tns_name:
+                    resolved = _resolve_fink_objects(obj.tns_name)
 
                 total_points = 0
 
                 if resolved:
                     for survey_name, fink_object_id in resolved:
                         survey = next(
-                            s for s in FINK_SURVEYS if s['name'] == survey_name
+                            s for s in FINK_SURVEYS if s["name"] == survey_name
                         )
                         stmt = Instrument.select(session.user_or_token).where(
-                            Instrument.name == survey['instrument_name']
+                            Instrument.name == survey["instrument_name"]
                         )
                         instrument = session.scalars(stmt).first()
                         if not instrument:
                             return self.error(
-                                f'Could not find any instrument named {survey["instrument_name"]}, '
-                                f'cannot post {survey_name.upper()} photometry from Fink'
+                                f"Could not find any instrument named {survey['instrument_name']}, "
+                                f"cannot post {survey_name.upper()} photometry from Fink"
                             )
                         total_points += _fetch_photometry_for_survey(
                             survey_name,
@@ -245,35 +262,39 @@ class FinkPhotometryHandler(BaseHandler):
                             self.associated_user_object,
                         )
                 else:
-                    # No TNS resolver match — try each name directly against both
-                    # ZTF and LSST Fink APIs (covers direct ZTF/LSST IDs)
-                    for name in names_to_resolve:
+                    # No TNS resolver match (or no TNS name) — try the object ID
+                    # and aliases directly against both ZTF and LSST Fink APIs.
+                    names_to_try = [object_id] + (obj.alias or [])
+                    for name in names_to_try:
                         if not name:
                             continue
                         for survey in FINK_SURVEYS:
                             stmt = Instrument.select(session.user_or_token).where(
-                                Instrument.name == survey['instrument_name']
+                                Instrument.name == survey["instrument_name"]
                             )
                             instrument = session.scalars(stmt).first()
                             if not instrument:
                                 continue
                             try:
                                 total_points += _fetch_photometry_for_survey(
-                                    survey['name'],
+                                    survey["name"],
                                     name,
                                     object_id,
                                     instrument.id,
                                     group_ids,
                                     self.associated_user_object,
                                 )
-                            except Exception:
-                                # This name may not exist in this survey — silently skip
+                            except Exception as e:
+                                log(
+                                    f"Could not fetch {survey['name'].upper()} photometry "
+                                    f"from Fink for name '{name}': {e}"
+                                )
                                 continue
 
                 self.push_all(
-                    action='skyportal/REFRESH_SOURCE_PHOTOMETRY',
-                    payload={'obj_id': obj.id, 'magsys': current_magsys},
+                    action="skyportal/REFRESH_SOURCE_PHOTOMETRY",
+                    payload={"obj_id": obj.id, "magsys": current_magsys},
                 )
-                return self.success(data={'total_points': total_points})
+                return self.success(data={"total_points": total_points})
         except Exception as e:
             return self.error(str(e))

--- a/extensions/skyportal/skyportal/handlers/api/fink_photometry.py
+++ b/extensions/skyportal/skyportal/handlers/api/fink_photometry.py
@@ -10,7 +10,180 @@ from ...models import Instrument
 from astropy.time import Time
 from .photometry import add_external_photometry
 
-bands = {1: 'ztfg', 2: 'ztfr', 3: 'ztfi'}
+FINK_ZTF_API = 'https://api.ztf.fink-portal.org'
+FINK_LSST_API = 'https://api.lsst.fink-portal.org'
+
+ZTF_BANDS = {1: 'ztfg', 2: 'ztfr', 3: 'ztfi'}
+LSST_BANDS = {'u': 'lsstu', 'g': 'lsstg', 'r': 'lsstr', 'i': 'lssti', 'z': 'lsstz', 'y': 'lssty'}
+
+# Keep legacy alias for backwards compatibility
+bands = ZTF_BANDS
+
+FINK_SURVEYS = [
+    {
+        'name': 'ztf',
+        'base_url': FINK_ZTF_API,
+        'instrument_name': 'ZTF',
+    },
+    {
+        'name': 'lsst',
+        'base_url': FINK_LSST_API,
+        'instrument_name': 'LSST',
+    },
+]
+
+
+def _resolve_fink_objects(names):
+    """
+    Resolve a list of names (object ID + aliases) using Fink TNS resolvers.
+
+    For each name, queries both ZTF and LSST Fink resolvers and returns a
+    deduplicated list of (survey_name, fink_object_id) tuples.
+    """
+    results = []
+    seen = set()
+    for name in names:
+        if not name:
+            continue
+        for survey in FINK_SURVEYS:
+            try:
+                r = requests.get(
+                    f'{survey["base_url"]}/api/v1/resolver',
+                    params={'name': name, 'resolver': 'tns'},
+                    timeout=10,
+                )
+                if r.status_code != 200 or not r.content:
+                    continue
+                data = r.json()
+                if not isinstance(data, list):
+                    continue
+                for item in data:
+                    obj_id = item.get('i:objectId') or item.get('d:objectId')
+                    key = (survey['name'], obj_id)
+                    if obj_id and key not in seen:
+                        seen.add(key)
+                        results.append(key)
+            except Exception:
+                continue
+    return results
+
+
+def _fetch_ztf_photometry(fink_object_id, obj_id, instrument_id, group_ids, user):
+    """Fetch ZTF photometry from Fink and post it to SkyPortal."""
+    r = requests.post(
+        f'{FINK_ZTF_API}/api/v1/objects',
+        json={
+            'objectId': fink_object_id,
+            'output-format': 'json',
+            'withupperlim': True,
+        },
+    )
+    if r.status_code != 200:
+        raise ValueError(
+            f"Request to Fink ZTF API failed for object {fink_object_id} (status {r.status_code})"
+        )
+
+    df = pd.read_json(io.BytesIO(r.content))
+    if len(df.index) == 0:
+        return
+
+    desired_columns = [
+        'i:objectId',
+        'i:ra',
+        'i:dec',
+        'i:magpsf',
+        'i:sigmapsf',
+        'i:diffmaglim',
+        'i:fid',
+        'i:jd',
+    ]
+    if not set(desired_columns).issubset(set(df.columns)):
+        raise ValueError(
+            f"Missing expected columns in Fink ZTF response for object {fink_object_id}"
+        )
+
+    data = {
+        'obj_id': [obj_id] * len(df),
+        'ra': df['i:ra'],
+        'dec': df['i:dec'],
+        'mag': df['i:magpsf'],
+        'magerr': df['i:sigmapsf'],
+        'limiting_mag': df['i:diffmaglim'],
+        'filter': [ZTF_BANDS[int(band)] for band in df['i:fid']],
+        'mjd': [Time(float(jd), format="jd").mjd for jd in df["i:jd"]],
+        'magsys': ['ab'] * len(df),
+        'instrument_id': instrument_id,
+        'group_ids': group_ids,
+    }
+    add_external_photometry(data, user)
+    return len(df)
+
+
+def _fetch_lsst_photometry(fink_object_id, obj_id, instrument_id, group_ids, user):
+    """Fetch LSST photometry from Fink (flux-space, nJy, zp=31.4) and post it to SkyPortal."""
+    r = requests.post(
+        f'{FINK_LSST_API}/api/v1/objects',
+        json={
+            'objectId': fink_object_id,
+            'output-format': 'json',
+            'withupperlim': True,
+        },
+    )
+    if r.status_code != 200:
+        raise ValueError(
+            f"Request to Fink LSST API failed for object {fink_object_id} (status {r.status_code})"
+        )
+
+    df = pd.read_json(io.BytesIO(r.content))
+    if len(df.index) == 0:
+        return
+
+    desired_columns = [
+        'd:objectId',
+        'd:ra',
+        'd:dec',
+        'd:psfFlux',
+        'd:psfFluxErr',
+        'd:band',
+        'd:midpointMjdTai',
+    ]
+    if not set(desired_columns).issubset(set(df.columns)):
+        raise ValueError(
+            f"Missing expected columns in Fink LSST response for object {fink_object_id}"
+        )
+
+    unknown_bands = set(df['d:band']) - set(LSST_BANDS)
+    if unknown_bands:
+        raise ValueError(
+            f"Unknown LSST band(s) in Fink response: {unknown_bands}"
+        )
+
+    data = {
+        'obj_id': [obj_id] * len(df),
+        'ra': df['d:ra'],
+        'dec': df['d:dec'],
+        'flux': df['d:psfFlux'],
+        'fluxerr': df['d:psfFluxErr'],
+        'filter': [LSST_BANDS[b] for b in df['d:band']],
+        'mjd': df['d:midpointMjdTai'],
+        'magsys': ['ab'] * len(df),
+        'zp': [31.4] * len(df),
+        'instrument_id': instrument_id,
+        'group_ids': group_ids,
+    }
+    add_external_photometry(data, user)
+    return len(df)
+
+
+def _fetch_photometry_for_survey(
+    survey_name, fink_object_id, obj_id, instrument_id, group_ids, user
+):
+    """Dispatch photometry fetching to the correct survey handler. Returns row count."""
+    if survey_name == 'ztf':
+        return _fetch_ztf_photometry(fink_object_id, obj_id, instrument_id, group_ids, user) or 0
+    elif survey_name == 'lsst':
+        return _fetch_lsst_photometry(fink_object_id, obj_id, instrument_id, group_ids, user) or 0
+    return 0
 
 
 class FinkPhotometryHandler(BaseHandler):
@@ -35,58 +208,72 @@ class FinkPhotometryHandler(BaseHandler):
                 if not obj:
                     return self.error("Object not found")
 
-                r = requests.post(
-                    'https://api.fink-portal.org/api/v1/objects',
-                    json={'objectId': object_id, 'output-format': 'json', 'withupperlim': True},
-                )
-                if r.status_code != 200:
-                    return self.error("Request to Fink's API failed")
+                group_ids = [
+                    g.id
+                    for g in self.current_user.accessible_groups
+                    if not g.single_user_group
+                ]
 
-                df_request = pd.read_json(io.BytesIO(r.content))
-                if len(df_request.index) > 0:
-                    desired_columns = [
-                        'i:objectId',
-                        'i:ra',
-                        'i:dec',
-                        'i:magpsf',
-                        'i:sigmapsf',
-                        'i:diffmaglim',
-                        'i:fid',
-                        'i:jd',
-                    ]
-                    if not set(desired_columns).issubset(set(df_request.columns)):
-                        return self.error('Missing expected column')
+                # Collect all names to try: the skyportal object ID plus any aliases
+                names_to_resolve = [object_id] + (obj.alias or [])
 
-                    stmt = Instrument.select(session.user_or_token).where(
-                        Instrument.name == 'ZTF'
-                    )
-                    instrument = session.scalars(stmt).first()
-                    if not instrument:
-                        return self.error(
-                            'Could not find any instrument named ZTF, cannot post photometry from Fink'
+                # Try to resolve via Fink TNS resolvers on both ZTF and LSST endpoints
+                resolved = _resolve_fink_objects(names_to_resolve)
+
+                total_points = 0
+
+                if resolved:
+                    for survey_name, fink_object_id in resolved:
+                        survey = next(
+                            s for s in FINK_SURVEYS if s['name'] == survey_name
                         )
-
-                    data = {
-                        'obj_id': df_request['i:objectId'],
-                        'ra': df_request['i:ra'],
-                        'dec': df_request['i:dec'],
-                        'mag': df_request['i:magpsf'],
-                        'magerr': df_request['i:sigmapsf'],
-                        'limiting_mag': df_request['i:diffmaglim'],
-                        'filter': [bands[int(band)] for band in df_request['i:fid']],
-                        'mjd': [Time(float(jd), format="jd").mjd for jd in df_request["i:jd"]],
-                        'magsys': ['ab' for i in range(len(df_request))],
-                        'instrument_id': instrument.id,
-                        'group_ids': [
-                            g.id for g in self.current_user.accessible_groups if not g.single_user_group
-                        ],
-                    }
-                    add_external_photometry(data, self.associated_user_object)
+                        stmt = Instrument.select(session.user_or_token).where(
+                            Instrument.name == survey['instrument_name']
+                        )
+                        instrument = session.scalars(stmt).first()
+                        if not instrument:
+                            return self.error(
+                                f'Could not find any instrument named {survey["instrument_name"]}, '
+                                f'cannot post {survey_name.upper()} photometry from Fink'
+                            )
+                        total_points += _fetch_photometry_for_survey(
+                            survey_name,
+                            fink_object_id,
+                            object_id,
+                            instrument.id,
+                            group_ids,
+                            self.associated_user_object,
+                        )
+                else:
+                    # No TNS resolver match — try each name directly against both
+                    # ZTF and LSST Fink APIs (covers direct ZTF/LSST IDs)
+                    for name in names_to_resolve:
+                        if not name:
+                            continue
+                        for survey in FINK_SURVEYS:
+                            stmt = Instrument.select(session.user_or_token).where(
+                                Instrument.name == survey['instrument_name']
+                            )
+                            instrument = session.scalars(stmt).first()
+                            if not instrument:
+                                continue
+                            try:
+                                total_points += _fetch_photometry_for_survey(
+                                    survey['name'],
+                                    name,
+                                    object_id,
+                                    instrument.id,
+                                    group_ids,
+                                    self.associated_user_object,
+                                )
+                            except Exception:
+                                # This name may not exist in this survey — silently skip
+                                continue
 
                 self.push_all(
                     action='skyportal/REFRESH_SOURCE_PHOTOMETRY',
                     payload={'obj_id': obj.id, 'magsys': current_magsys},
                 )
-                return self.success()
+                return self.success(data={'total_points': total_points})
         except Exception as e:
             return self.error(str(e))

--- a/extensions/skyportal/static/js/components/source/AddFinkPhot.jsx
+++ b/extensions/skyportal/static/js/components/source/AddFinkPhot.jsx
@@ -1,13 +1,15 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { useSelector, useDispatch } from "react-redux";
 import Button from "@mui/material/Button";
+import CircularProgress from "@mui/material/CircularProgress";
 
 import { showNotification } from "baselayer/components/Notifications";
 import postFinkPhot from "../../ducks/fink_phot";
 
 const AddPhotFink = ({ id }) => {
   const dispatch = useDispatch();
+  const [loading, setLoading] = useState(false);
   const currentUser = useSelector((state) => state.profile);
   const photometry = useSelector((state) => state.photometry[id]);
   const permission =
@@ -24,23 +26,45 @@ const AddPhotFink = ({ id }) => {
   };
 
   const handleAddPhotFink = (source_id) => {
+    setLoading(true);
     dispatch(postFinkPhot(source_id, current_magsys(photometry)))
       .then((result) => {
         if (result.status === "success") {
-          dispatch(showNotification("Fink photometry added"));
+          const n = result.data?.total_points ?? 0;
+          if (n === 0) {
+            dispatch(
+              showNotification(
+                `No photometry found in Fink for ${source_id}`,
+                "warning"
+              )
+            );
+          } else {
+            dispatch(
+              showNotification(
+                `Added ${n} point${n !== 1 ? "s" : ""} to ${source_id}`
+              )
+            );
+          }
         } else {
+          const message = result.message || "unknown error";
           dispatch(
-            showNotification("Fink photometry could not be added", "error")
+            showNotification(
+              `Could not retrieve Fink photometry: ${message}`,
+              "error"
+            )
           );
         }
       })
       .catch((error) => {
         dispatch(
           showNotification(
-            `Fink photometry could not be added: ${error}`,
+            `Could not retrieve Fink photometry: ${error?.message || error}`,
             "error"
           )
         );
+      })
+      .finally(() => {
+        setLoading(false);
       });
   };
 
@@ -52,9 +76,11 @@ const AddPhotFink = ({ id }) => {
         onClick={() => {
           handleAddPhotFink(id);
         }}
+        disabled={loading}
+        startIcon={loading ? <CircularProgress size={14} color="inherit" /> : null}
         data-testid="add-phot-fink"
       >
-        Fink Photometry
+        {loading ? "Fetching..." : "Fink Photometry"}
       </Button>
     )
   );


### PR DESCRIPTION
The goal of this PR is to:
* Add support for LSST survey.
* Change default behaviour that was only based on object id name (so it only work for ZTF sources). Now we also try to find it by TNS name and alias
* Add some logs and explicit notifications (number of points added in case of success and error message if it failed).