### PR TITLE
use skyportal-data

### DIFF
--- a/.github/workflows/test_icare_extensions.yaml
+++ b/.github/workflows/test_icare_extensions.yaml
@@ -56,9 +56,17 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+          # Pull the skyportal-data submodule's LFS payload (SFD dust maps and
+          # sncosmo SED models); bandpasses/spectra are plain git.
+          lfs: true
 
       - name: Fetch submodules
-        run: git submodule update --init --recursive
+        run: |
+          git submodule update --init --recursive
+          # Ensure the nested skyportal-data LFS payload is materialized (real
+          # FITS files, not pointers) before icare copies skyportal/ into
+          # patched_skyportal/.
+          git -C skyportal/skyportal-data lfs pull
 
       - uses: browser-actions/setup-geckodriver@latest
         with:
@@ -84,16 +92,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-sncosmo-
 
-      # Dustmap (SFD) cache — same pattern. Without this, skyportal/models/
-      # obj.py triggers a ~128 MB dustmaps.sfd.fetch() at import time, which
-      # blocks tornado workers long enough that test_frontend's 180 s
-      # verify_server_availability poll gives up with HTTP 503.
-      - uses: actions/cache@v5
-        with:
-          path: patched_skyportal/persistentdata/dustmap/sfd
-          key: ${{ runner.os }}-dustmap-${{ hashFiles('skyportal/uv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-dustmap-
+      # The SFD dust maps are now vendored in the skyportal-data submodule
+      # (misc.dustmap_folder = skyportal-data/dustmaps) and pulled via LFS in
+      # the checkout above, so the previous ~128 MB import-time fetch and its
+      # host-side cache are no longer needed.
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -190,23 +192,9 @@ jobs:
           cd patched_skyportal
           PYTHONPATH=. timeout 120 python tools/warm_sncosmo_cache.py || true
 
-      - name: Pre-fetch SFD dustmap
-        # skyportal/models/obj.py calls dustmaps.sfd.fetch() at import time
-        # if the SFD FITS files are missing — ~128 MB pulled over the network
-        # while tornado workers are trying to come up. Do it here instead, so
-        # the cache step above keeps it warm between runs and the app start
-        # is purely local I/O.
-        run: |
-          cd patched_skyportal
-          mkdir -p persistentdata/dustmap
-          PYTHONPATH=. python -c "
-          from dustmaps.config import config
-          config['data_dir'] = 'persistentdata/dustmap'
-          import dustmaps.sfd, os
-          required = ['sfd/SFD_dust_4096_ngp.fits', 'sfd/SFD_dust_4096_sgp.fits']
-          if any(not os.path.isfile(os.path.join('persistentdata/dustmap', f)) for f in required):
-              dustmaps.sfd.fetch()
-          " || true
+      # The SFD dust maps are vendored in skyportal-data/dustmaps (copied into
+      # patched_skyportal/ by the build) and referenced via misc.dustmap_folder,
+      # so obj.py reads them locally with no import-time download.
 
       - name: Run icare-specific tests
         # Mirrors fritz's `./fritz test` model: only run tests that live

--- a/.github/workflows/test_icare_extensions.yaml
+++ b/.github/workflows/test_icare_extensions.yaml
@@ -88,9 +88,9 @@ jobs:
             ${{ runner.os }}-sncosmo-
 
       # The SFD dust maps are now vendored in the skyportal-data submodule
-      # (misc.dustmap_folder = skyportal-data/dustmaps) and pulled via LFS in
-      # the checkout above, so the previous ~128 MB import-time fetch and its
-      # host-side cache are no longer needed.
+      # (misc.dustmap_folder = skyportal-data/dustmaps), materialized by the
+      # recursive submodule checkout above, so the previous ~128 MB import-time
+      # fetch and its host-side cache are no longer needed.
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/test_icare_extensions.yaml
+++ b/.github/workflows/test_icare_extensions.yaml
@@ -56,17 +56,12 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-          # Pull the skyportal-data submodule's LFS payload (SFD dust maps and
-          # sncosmo SED models); bandpasses/spectra are plain git.
-          lfs: true
 
       - name: Fetch submodules
-        run: |
-          git submodule update --init --recursive
-          # Ensure the nested skyportal-data LFS payload is materialized (real
-          # FITS files, not pointers) before icare copies skyportal/ into
-          # patched_skyportal/.
-          git -C skyportal/skyportal-data lfs pull
+        # skyportal-data (SFD dust maps + sncosmo models) is vendored as plain
+        # git blobs in the submodule, so a recursive update brings the real
+        # files in before icare copies skyportal/ into patched_skyportal/.
+        run: git submodule update --init --recursive
 
       - uses: browser-actions/setup-geckodriver@latest
         with:


### PR DESCRIPTION
This PR updates the skyportal commit, which now uses a dedicated repo for the flaky external data.